### PR TITLE
reword the Achtung! about wrapping calls that may generate stack traces

### DIFF
--- a/examples/exception_like.t
+++ b/examples/exception_like.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More;
+use Test::Fatal;
+use Carp 'confess';
+
+sub exception_like(&$;$)
+{   
+  my ($code, $pattern, $name) = @_;
+  like( &exception($code), $pattern, $name );
+}
+
+exception_like(sub { confess 'blah blah' }, qr/foo/, 'foo seems to appear in the exception');
+
+# the test only passes when we invert it
+unlike(
+    ( exception { confess 'blah blah' } || '' ),
+    qr/foo/,
+    'foo does NOT ACTUALLY appear in the exception',
+);
+
+done_testing;

--- a/lib/Test/Fatal.pm
+++ b/lib/Test/Fatal.pm
@@ -73,14 +73,19 @@ C<Sub::Uplevel> mechanism.
 
 B<Achtung!>  This is not a great idea:
 
-  like( exception { ... }, qr/foo/, "foo appears in the exception" );
+  sub exception_like(&$;$) {
+      my ($code, $pattern, $name) = @_;
+      like( &exception($code), $pattern, $name );
+  }
+
+  exception_like(sub { }, qr/foo/, 'foo appears in the exception');
 
 If the code in the C<...> is going to throw a stack trace with the arguments to
-each subroutine in its call stack, the test name, "foo appears in the
-exception" will itself be matched by the regex.  Instead, write this:
+each subroutine in its call stack (for example via C<Carp::confess>,
+the test name, "foo appears in the exception" will itself be matched by the
+regex.  Instead, write this:
 
-  my $exception = exception { ... };
-  like( $exception, qr/foo/, "foo appears in the exception" );
+  like( exception { ... }, qr/foo/, 'foo appears in the exception' );
 
 B<Achtung>: One final bad idea:
 


### PR DESCRIPTION
The example in the documentation is not actually a problem. What is of concern
is a wrapper sub that includes the regex in its arguments, which will then
cause a false positive via the stack trace that is produced.

The example was adapted from a similar warning in Test::Warnings, which
originally came from this dist itself, and then amended several times after
conversations with ribasushi.
