### PR TITLE
Skip todo tests with newer builder

### DIFF
--- a/t/todo.t
+++ b/t/todo.t
@@ -2,10 +2,22 @@
 
 use strict;
 
-use Test::Builder::Tester tests => 4;
+use Test::Builder::Tester;
 
 use Test::More;
 use Test::Fatal;
+
+if (eval { require Test::Builder::Provider; 1 }) {
+    # Test::Builder has been updated recently to no longer use $Level, instead
+    # it uses a system of marking subs and using intelligent stack traces. Some
+    # $Level support still exists for legacy code.
+    # The problem here is that Test::Builder and this module disagree on where
+    # things should trace to. See #TB TODO notes below.
+    plan 'skip_all' => "Newer Test::Builder makes this test irrelevent, and broken";
+}
+else {
+    plan tests => 4;
+}
 
 {
     my $line = __LINE__ + 13;
@@ -48,7 +60,7 @@ FAIL
         my ($got, $expected) = @_;
         local $Test::Builder::Level = $Test::Builder::Level + 1;
         is(
-            exception { is($got, $expected, "succeeded") },
+            exception { is($got, $expected, "succeeded") }, #TB TODO: The error should trace here, to the 'is' call
             undef,
             "no exceptions"
         );
@@ -83,7 +95,7 @@ FAIL
         my ($got, $expected) = @_;
         local $Test::Builder::Level = $Test::Builder::Level + 1;
         is(
-            exception { is($got, $expected, "succeeded") },
+            exception { is($got, $expected, "succeeded") }, #TB TODO: Same
             undef,
             "no exceptions"
         );
@@ -123,7 +135,7 @@ FAIL
         my ($got, $expected) = @_;
         local $Test::Builder::Level = $Test::Builder::Level + 1;
         is(
-            exception { is($got, $expected, "succeeded") },
+            exception { is($got, $expected, "succeeded") }, #TB TODO: And again
             undef,
             "no exceptions"
         );


### PR DESCRIPTION
The Result_Stream branch, which should be released in the next several
weeks (months?) gets rid of $Level. This test breaks with the newer
Test::Builder which uses a better way to figure out who called it and
when. The results this test expects differ from the design of the newer
builder.
