### PR TITLE
relax Test::More prereq

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,3 +5,9 @@ copyright_holder = Ricardo Signes
 copyright_year   = 2010
 
 [@RJBS]
+
+[RemovePrereqs]
+remove = Test::More
+
+[Prereqs / TestRequires]
+Test::More = 0.65

--- a/t/todo.t
+++ b/t/todo.t
@@ -4,10 +4,19 @@ use strict;
 
 use Test::Builder::Tester tests => 4;
 
-use Test::More;
+use Test::More 0.65;
 use Test::Fatal;
 
 my $file = __FILE__;
+
+if (!eval { Test::Builder::Tester->VERSION(1.20) }) { # Test::More 0.96
+    my $builder = Test::Builder->new;
+    no warnings 'redefine';
+    *test_out = sub {
+        Test::Builder::Tester::test_out(@_);
+        $builder->todo_output($builder->output);
+    }
+}
 
 {
     my $line = __LINE__ + 13;


### PR DESCRIPTION
Test::More older than 0.96 ships with a Test::Builder::Tester that
handles TODO output incorrectly.  This can be easily worked around.
With that change, we only require Test::More 0.65.  Versions older than
0.65 format the TODO output differently.

The version prereq was previously bumped due to this and some other tests using done_testing (#5), but those other tests have either been removed or changed.
