### PR TITLE
do not complain when a false exception is blessed

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - now tolerant of false exceptions coming from a boolean-overloaded
+          object
 
 0.015     2018-03-10 17:06:11-05:00 America/New_York (TRIAL RELEASE)
         - add default descriptions to tests

--- a/lib/Test/Fatal.pm
+++ b/lib/Test/Fatal.pm
@@ -65,6 +65,7 @@ indicates a serious problem with the system under testing, this behavior is
 considered a I<feature>.  If you must test for these conditions, you should use
 L<Try::Tiny>'s try/catch mechanism.  (Try::Tiny is the underlying exception
 handling system of Test::Fatal.)
+Note that this issue is only known to occur on perls before 5.14.
 
 Note that there is no TAP assert being performed.  In other words, no "ok" or
 "not ok" line is emitted.  It's up to you to use the rest of C<exception> in an

--- a/t/basic.t
+++ b/t/basic.t
@@ -71,9 +71,9 @@ SKIP: {
   use overload 'bool' => sub { 0 };
 }
 
-like(
+is(
   exception { exception { die(bless {} => 'FalseObject'); } },
-  qr{false exception},
-  "we throw a new exception if the exception is false",
+  undef,
+  "we do not throw a new exception if the exception is false but blessed",
 );
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -51,17 +51,18 @@ try {
 
 {
   package BreakException;
-  sub DESTROY { eval { my $x = 'o no'; } }
+  sub DESTROY { eval { my $x = 'o no'; } }  # resets $@ to '' on older perls
 }
 
-if ($] < 5.013001) {
+SKIP: {
+  skip 'perl < 5.013001 required to test $@ being altered in DESTROY', 1 if $] >= 5.013001;
   like(
     exception { exception {
       my $blackguard = bless {}, 'BreakException';
       die "real exception";
     } },
     qr{false exception},
-    "we throw a new exception if the exception is false",
+    'DESTROY resets $@ to false; we throw a new exception if the exception is false',
   );
 }
 


### PR DESCRIPTION
This allows for testing of exceptions consisting of objects with a boolean overload. The original problem being checked for, where $@ can be altered by a DESTROY method, was fixed in perl 5.13.1.